### PR TITLE
Implement want-digest header

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,8 +8,9 @@ Description: A Git LFS client library compatible with Giftless
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-Imports:
+Depends:
     httr,
     digest,
-    jsonlite
+    jsonlite,
+    openssl
     

--- a/R/batch.R
+++ b/R/batch.R
@@ -13,12 +13,12 @@ batch <- function(prefix, objects, token, transfers) {
   body <- list(
     operation = c("upload"),
     transfers = transfers,
-    ref = list(name = "refs/heads/contrib"),
+    ref = list(name = "refs/heads/master"),
     objects = objects
     )
 
   resp <- POST(url, body = body, config = header, encode = 'json')
-  parsed <- jsonlite::fromJSON(content(resp, "text"), simplifyVector = FALSE)
+  parsed <- parse_response(resp)
 
   if (http_error(resp)) {
     stop(

--- a/R/multipart_transfer_adapter.R
+++ b/R/multipart_transfer_adapter.R
@@ -2,16 +2,11 @@
 #'
 #' @return Giftless API token
 multipart_upload <- function(file_path, upload_specs) {
-  if(!'actions' %in% names(upload_specs)){
-    print("No actions, file already exists")
-    return
-  }
-
   actions <- upload_specs$actions
 
   for (part in actions$parts) {
     print("Uploading part")
-    upload_part(file_path, part$href, part$pos, part$size, part$want_diggest)
+    upload_part(file_path, part$href, part$pos, part$size, part$want_digest)
   }
 
   if('commit' %in% names(actions)){
@@ -21,11 +16,11 @@ multipart_upload <- function(file_path, upload_specs) {
         commit$href,
         config = do.call(add_headers, commit$header),
         body = commit$body,
-        encode='char'
+        encode='raw'
         )
 
     if (http_error(resp)) {
-      parsed <- jsonlite::fromJSON(content(resp, "text"), simplifyVector = FALSE)
+      parsed <- parse_response(resp)
       stop(
         sprintf("Error when executing commit action [%s]\n%s", status_code(resp), parsed$message),
         call. = FALSE

--- a/R/upload.R
+++ b/R/upload.R
@@ -1,6 +1,6 @@
 #' Upload a file to LFS storage
 #'
-#' @return Giftless API token
+#' @return list with sha256 and size of the object
 lfs_upload <- function(file_path, repo, dataset, token, transfers=c("multipart-basic", "basic")) {
   hash <- digest(file=file_path, algo='sha256')
   size <- file.size(file_path)
@@ -10,6 +10,11 @@ lfs_upload <- function(file_path, repo, dataset, token, transfers=c("multipart-b
   resp <- batch(prefix, object, token, transfers)
 
   upload_specs <- resp$objects[[1]]
+  if(!'actions' %in% names(upload_specs)){
+    print("No actions, file already exists")
+    return(list(sha256=hash, size=size))
+  }
+
   transfer <- resp$transfer
   if (transfer == 'multipart-basic'){
     print("Initiating multipart-basic upload")
@@ -20,4 +25,6 @@ lfs_upload <- function(file_path, repo, dataset, token, transfers=c("multipart-b
     print("Initiating basic upload")
     basic_upload(file_path, upload_specs)
   }
+
+  return(list(sha256=hash, size=size))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,7 +37,7 @@ calculate_want_digest <- function(data, want_digest){
     encoded_digest <- openssl::base64_encode(md5)
     return(encoded_digest)
   } else {
-    stop(paste(want_diggest, "method for want_diggest is not supported."), call. = FALSE)
+    stop(paste(want_digest, "method for want_digest is not supported."), call. = FALSE)
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,10 +10,54 @@ get_lfs_server_url <- function() {
 }
 
 #' Uploads a file part to a signed_url given size and initial file offset.
-upload_part <- function(file_path, href, pos, size, want_digest){
+upload_part <- function(file_path, href, pos, size, want_digest=NULL){
   con <- file(file_path, 'rb')
   on.exit(close(con))
   seek(con, where = pos)
   data <- readBin(con, raw(), n = size)
-  PUT(href, body = data, encode = 'raw')
+
+  headers <- add_headers()
+  if(!is.null(want_digest)){
+    part_digest <- calculate_want_digest(data, want_digest)
+    print(part_digest)
+    headers <- add_headers(`Content-MD5` = part_digest)
+  }
+
+  resp <- PUT(href, config = headers, body = data, encode = 'raw')
+  if(http_error(resp)){
+    stop("Unexpected reply from server for upload.")
+  }
+}
+
+#' Calculates a digest for the uploading part
+#'
+calculate_want_digest <- function(data, want_digest){
+  if(want_digest == 'contentMD5'){
+    md5 <- digest(data, algo = 'md5', serialize = FALSE, raw=TRUE)
+    encoded_digest <- openssl::base64_encode(md5)
+    return(encoded_digest)
+  } else {
+    stop(paste(want_diggest, "method for want_diggest is not supported."), call. = FALSE)
+  }
+}
+
+#' Parse response given the return type of the API
+#'
+parse_response <- function(resp){
+  if(http_type(resp) == "application/vnd.git-lfs+json") {
+    parsed <- jsonlite::fromJSON(content(resp, "text"), simplifyVector = FALSE)
+    return(parsed)
+  }
+
+  # Azure API returns an xml response for some errors that we need to parse
+  if(http_type(resp) == "application/xml" && http_error(resp)){
+    resp_content <- xml2::as_list(content(resp))
+    parsed <- list(
+      code = resp_content$Error$Code,
+      message = resp_content$Error$Message
+    )
+    return(parsed)
+  }
+
+  stop("Couldn't parse response data from the API.", call. = FALSE)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,7 +19,6 @@ upload_part <- function(file_path, href, pos, size, want_digest=NULL){
   headers <- add_headers()
   if(!is.null(want_digest)){
     part_digest <- calculate_want_digest(data, want_digest)
-    print(part_digest)
     headers <- add_headers(`Content-MD5` = part_digest)
   }
 


### PR DESCRIPTION
This PR adds logic to implement a base64 encoded MD5 digest header for every part uploaded using multipar-basic transfer protocol.