### PR TITLE
Add extra headers parameter to lfs_upload and batch functions

### DIFF
--- a/R/batch.R
+++ b/R/batch.R
@@ -1,15 +1,17 @@
 #' Send a batch request to the LFS server
 #'
-#' @return Signed URL to
-batch <- function(prefix, objects, token, transfers) {
-  path <- paste0(prefix, '/objects/batch')
-  url <- modify_url(get_lfs_server_url(), path = path)
+#' @return List with upload specifications for the given objects
+batch <- function(prefix, objects, token, transfers, headers = c()) {
+  batch_path <- paste0(prefix, '/objects/batch')
+  url <- paste(get_lfs_server_url(), batch_path, sep = '/')
 
   header <- add_headers(
     Accept = "application/vnd.git-lfs+json",
     `Content-Type` = "application/vnd.git-lfs+json",
-    Authorization = paste('Bearer', token)
+    Authorization = paste('Bearer', token),
+    .headers = headers
   )
+
   body <- list(
     operation = c("upload"),
     transfers = transfers,

--- a/R/multipart_transfer_adapter.R
+++ b/R/multipart_transfer_adapter.R
@@ -1,6 +1,4 @@
 #' Do a multipart upload
-#'
-#' @return Giftless API token
 multipart_upload <- function(file_path, upload_specs) {
   actions <- upload_specs$actions
 

--- a/R/upload.R
+++ b/R/upload.R
@@ -1,13 +1,13 @@
 #' Upload a file to LFS storage
 #'
 #' @return list with sha256 and size of the object
-lfs_upload <- function(file_path, repo, dataset, token, transfers=c("multipart-basic", "basic")) {
+lfs_upload <- function(file_path, repo, dataset, token, transfers=c("multipart-basic", "basic"), headers = c()) {
   hash <- digest(file=file_path, algo='sha256')
   size <- file.size(file_path)
   object <- list(list(oid = hash, size = size))
   prefix <- paste0(repo, '/', dataset)
 
-  resp <- batch(prefix, object, token, transfers)
+  resp <- batch(prefix, object, token, transfers, headers = headers)
 
   upload_specs <- resp$objects[[1]]
   if(!'actions' %in% names(upload_specs)){


### PR DESCRIPTION
This PR allows send extra headers to the `lfs_upload` and `batch` functions if needed.