### PR TITLE
Add file_size function

### DIFF
--- a/R/upload.R
+++ b/R/upload.R
@@ -13,7 +13,7 @@
 #' @return list with sha256 and size of the object
 lfs_upload <- function(file_path, repo, dataset, token, transfers=c("multipart-basic", "basic"), headers = c()) {
   hash <- digest(file=file_path, algo='sha256')
-  size <- file.size(file_path)
+  size <- file_size(file_path)
   object <- list(list(oid = hash, size = size))
   prefix <- paste0(repo, '/', dataset)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -82,3 +82,15 @@ parse_response <- function(resp){
 
   stop("Couldn't parse response data from the API.", call. = FALSE)
 }
+
+#' Wrapper for R's file.size(...) function
+#'
+#' This is a workaround for situations where R returns a scientific notation
+#' value.
+#'
+#'@param file_path character. string naming a file
+#'
+#'@returns A character with the size in KB of the file
+file_size <- function(file_path){
+  format(file.size(file_path), scientific = FALSE)
+}


### PR DESCRIPTION
When R returns a size in a scientific notation, the POST method was sending it as a string (e.g. `5e+06`). So to avoid a global solution using `options(scipen = 999)` I format it as a character string before creating the list object.